### PR TITLE
column database type names

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -44,3 +44,54 @@ func (r *Rows) Next(dest []driver.Value) error {
 func (r *Rows) Close() error {
 	return r.os.closeByRows()
 }
+
+// ColumnTypeDatabaseTypeName return the database system type name.
+func (r *Rows) ColumnTypeDatabaseTypeName(index int) string {
+	switch x := r.os.Cols[index].(type) {
+	case *BindableColumn:
+		return cTypeString(x.CType)
+	case *NonBindableColumn:
+		return cTypeString(x.CType)
+	}
+	return ""
+}
+
+func cTypeString(ct api.SQLSMALLINT) string {
+	switch ct {
+	case api.SQL_C_CHAR:
+		return "SQL_C_CHAR"
+	case api.SQL_C_LONG:
+		return "SQL_C_LONG"
+	case api.SQL_C_SHORT:
+		return "SQL_C_SHORT"
+	case api.SQL_C_FLOAT:
+		return "SQL_C_FLOAT"
+	case api.SQL_C_DOUBLE:
+		return "SQL_C_DOUBLE"
+	case api.SQL_C_NUMERIC:
+		return "SQL_C_NUMERIC"
+	case api.SQL_C_DATE:
+		return "SQL_C_DATE"
+	case api.SQL_C_TIME:
+		return "SQL_C_TIME"
+	case api.SQL_C_TYPE_TIMESTAMP:
+		return "SQL_C_TYPE_TIMESTAMP"
+	case api.SQL_C_TIMESTAMP:
+		return "SQL_C_TIMESTAMP"
+	case api.SQL_C_BINARY:
+		return "SQL_C_BINARY"
+	case api.SQL_C_BIT:
+		return "SQL_C_BIT"
+	case api.SQL_C_WCHAR:
+		return "SQL_C_WCHAR"
+	case api.SQL_C_DEFAULT:
+		return "SQL_C_DEFAULT"
+	case api.SQL_C_SBIGINT:
+		return "SQL_C_SBIGINT"
+	case api.SQL_C_UBIGINT:
+		return "SQL_C_UBIGINT"
+	case api.SQL_C_GUID:
+		return "SQL_C_GUID"
+	}
+	return ""
+}


### PR DESCRIPTION
from https://github.com/alexbrainman/odbc/pull/114/files

Column type (type name?) support is an excellent thing to have. Looking around github, I see there are a few different implementations of this. I'm not sure which is the ideal pick to merge, this one doesn't seem too bad as it just surfaces the SQL C types, which is a pretty reasonable first step.

I'll look around before merging this.