### PR TITLE
Fix compile warnings on macos

### DIFF
--- a/api/api_unix.go
+++ b/api/api_unix.go
@@ -7,8 +7,7 @@
 
 package api
 
-// #cgo darwin LDFLAGS: -L /usr/local/opt/unixodbc/lib -lodbc
-// #cgo darwin CFLAGS: -I /usr/local/opt/unixodbc/include
+// #cgo darwin pkg-config: odbc
 // #cgo linux LDFLAGS: -lodbc
 // #cgo freebsd LDFLAGS: -L /usr/local/lib -lodbc
 // #cgo freebsd CFLAGS: -I/usr/local/include

--- a/api/mksyscall_unix.pl
+++ b/api/mksyscall_unix.pl
@@ -121,7 +121,7 @@ package $package
 
 import "unsafe"
 
-// #cgo darwin LDFLAGS: -lodbc
+// #cgo darwin pkg-config: odbc
 // #cgo linux LDFLAGS: -lodbc
 // #cgo freebsd LDFLAGS: -L /usr/local/lib -lodbc
 // #cgo freebsd CFLAGS: -I/usr/local/include

--- a/api/zapi_unix.go
+++ b/api/zapi_unix.go
@@ -12,7 +12,7 @@ package api
 
 import "unsafe"
 
-// #cgo darwin LDFLAGS: -lodbc
+// #cgo darwin pkg-config: odbc
 // #cgo linux LDFLAGS: -lodbc
 // #cgo freebsd LDFLAGS: -L /usr/local/lib -lodbc
 // #cgo freebsd CFLAGS: -I/usr/local/include


### PR DESCRIPTION
Before

```
➜  polytomic git:(master) ✗ make build/cli
ld: warning: ignoring duplicate libraries: '-lodbc'
ld: warning: search path '/usr/local/opt/unixodbc/lib' not found
➜  polytomic git:(master) ✗
```

After

```
➜  polytomic git:(master) ✗ make build/cli
➜  polytomic git:(master) ✗
```

I suspect we could move linux/bsd to use pkg-config as well